### PR TITLE
Fix typos

### DIFF
--- a/codelst.typ
+++ b/codelst.typ
@@ -35,7 +35,7 @@
     gobble = codelst-gobble-count(code-lines)
   }
 
-  // Convert tabs to spaces and remove unecessary whitespace
+  // Convert tabs to spaces and remove unnecessary whitespace
   return code-lines.map((line) => {
     if line.len() > 0 {
       line = line.slice(gobble)

--- a/example.typ
+++ b/example.typ
@@ -27,7 +27,7 @@ This report is embedded in the ArtosFlow project. ArtosFlow is a project of the 
 
 /*
  Very long line without linebreak
- with a preceeding block comment
+ with a preceding block comment
 */
 This_report_is_embedded_in_the_ArtosFlow_project._ArtosFlow_is_a_project_of_the_Artos_Institute.
 

--- a/manual.typ
+++ b/manual.typ
@@ -168,7 +168,7 @@ project of the Artos Institute.
 ```]
 ````]
 
-CODELST handles whitespace in the code to save space and display the code as intended (and indented). Unnecessary blank lines at the beginning and end will be removed, alongside superfluous indention:
+CODELST handles whitespace in the code to save space and display the code as intended (and indented). Unnecessary blank lines at the beginning and end will be removed, alongside superfluous indentation:
 
 #example[````
 #sourcecode[```java
@@ -623,7 +623,7 @@ Setting up one of these catchall methods is easily done by using the #cmd[codels
   ```]
 ]
 
-= Limiations and alternatvies
+= Limitations and alternatvies
 
 == Limitations and Issues
 


### PR DESCRIPTION
Found via `typos --hidden --format brief`

Note that I can't get https://github.com/jneug/typst-mantys to install correct with my local typst installation, hence I cannot update the relevant PDF files.